### PR TITLE
news alterations in the landing finished

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -13,7 +13,7 @@
         "@tailwindcss/forms": "^0.5.7",
         "air-datepicker": "^3.5.3",
         "autoprefixer": "^10.4.19",
-        "esbuild-sass-plugin": "^3.2.0",
+        "esbuild-sass-plugin": "^3.3.1",
         "esbuild-style-plugin": "^1.6.3",
         "esbuild-wasm": "^0.21.2",
         "inputmask": "^5.0.7",
@@ -537,15 +537,16 @@
       }
     },
     "node_modules/esbuild-sass-plugin": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/esbuild-sass-plugin/-/esbuild-sass-plugin-3.2.0.tgz",
-      "integrity": "sha512-a+e7rYx4sDHgtKWN2n6/7lH5fgfvJaT6AMHmFhBKZy2ZTSN91X5q12l+DNVYJ8cWViEjJNWEd7k7UVcCg/2S/Q==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/esbuild-sass-plugin/-/esbuild-sass-plugin-3.3.1.tgz",
+      "integrity": "sha512-SnO1ls+d52n6j8gRRpjexXI8MsHEaumS0IdDHaYM29Y6gakzZYMls6i9ql9+AWMSQk/eryndmUpXEgT34QrX1A==",
       "dependencies": {
         "resolve": "^1.22.8",
+        "safe-identifier": "^0.4.2",
         "sass": "^1.71.1"
       },
       "peerDependencies": {
-        "esbuild": "^0.20.1",
+        "esbuild": ">=0.20.1",
         "sass-embedded": "^1.71.1"
       }
     },
@@ -1358,6 +1359,11 @@
       "dependencies": {
         "tslib": "^2.1.0"
       }
+    },
+    "node_modules/safe-identifier": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/safe-identifier/-/safe-identifier-0.4.2.tgz",
+      "integrity": "sha512-6pNbSMW6OhAi9j+N8V+U715yBQsaWJ7eyEUaOrawX+isg5ZxhUlV1NipNtgaKHmFGiABwt+ZF04Ii+3Xjkg+8w=="
     },
     "node_modules/sass": {
       "version": "1.75.0",

--- a/assets/package.json
+++ b/assets/package.json
@@ -11,7 +11,7 @@
     "@tailwindcss/forms": "^0.5.7",
     "air-datepicker": "^3.5.3",
     "autoprefixer": "^10.4.19",
-    "esbuild-sass-plugin": "^3.2.0",
+    "esbuild-sass-plugin": "^3.3.1",
     "esbuild-style-plugin": "^1.6.3",
     "esbuild-wasm": "^0.21.2",
     "inputmask": "^5.0.7",

--- a/config/config.exs
+++ b/config/config.exs
@@ -2,6 +2,10 @@ import Config
 
 config :pescarte, env: config_env()
 
+config :pescarte, PescarteWeb,
+  notice_title_max_length: 110,
+  notice_desc_max_length: 145
+
 config :supabase_gotrue,
   endpoint: PescarteWeb.Endpoint,
   signed_in_path: "/app/pesquisa/perfil",

--- a/lib/pescarte_web/templates/landing_html.ex
+++ b/lib/pescarte_web/templates/landing_html.ex
@@ -3,18 +3,43 @@ defmodule PescarteWeb.LandingHTML do
 
   embed_templates("landing_html/*")
 
-  def handle_notice_text_length(text, max_length) do
-    case String.length(text) do
-      text_length when text_length >= max_length ->
-        text =
-          text
-          |> String.slice(0..(max_length - 4))
-          |> String.trim_trailing()
+  @notice_title_max_length Application.compile_env!(:pescarte, [
+                             PescarteWeb,
+                             :notice_title_max_length
+                           ])
 
-        text <> "..."
+  @notice_desc_max_length Application.compile_env!(:pescarte, [
+                            PescarteWeb,
+                            :notice_desc_max_length
+                          ])
 
-      _text_length ->
-        text
+  def handle_notice_title_length(text) do
+    if String.length(text) > @notice_title_max_length do
+      text
+      |> truncate_text_until(@notice_title_max_length - 4)
+      |> put_ellipsis()
+    else
+      text
     end
+  end
+
+  def handle_notice_desc_length(text) do
+    if String.length(text) > @notice_desc_max_length do
+      text
+      |> truncate_text_until(@notice_desc_max_length - 4)
+      |> put_ellipsis()
+    else
+      text
+    end
+  end
+
+  defp truncate_text_until(text, length) do
+    text
+    |> String.slice(0..length)
+    |> String.trim_trailing()
+  end
+
+  defp put_ellipsis(text) do
+    text <> "..."
   end
 end

--- a/lib/pescarte_web/templates/landing_html.ex
+++ b/lib/pescarte_web/templates/landing_html.ex
@@ -5,9 +5,16 @@ defmodule PescarteWeb.LandingHTML do
 
   def handle_notice_text_length(text, max_length) do
     case String.length(text) do
-    text_length when (text_length >= max_length) ->
-    String.slice(text, 0..max_length - 4) <> "..."
-    _text_length -> text
+      text_length when text_length >= max_length ->
+        text =
+          text
+          |> String.slice(0..(max_length - 4))
+          |> String.trim_trailing()
+
+        text <> "..."
+
+      _text_length ->
+        text
     end
   end
 end

--- a/lib/pescarte_web/templates/landing_html.ex
+++ b/lib/pescarte_web/templates/landing_html.ex
@@ -2,4 +2,12 @@ defmodule PescarteWeb.LandingHTML do
   use PescarteWeb, :html
 
   embed_templates("landing_html/*")
+
+  def handle_notice_text_length(text, max_length) do
+    case String.length(text) do
+    text_length when (text_length >= max_length) ->
+    String.slice(text, 0..max_length - 4) <> "..."
+    _text_length -> text
+    end
+  end
 end

--- a/lib/pescarte_web/templates/landing_html/show.html.heex
+++ b/lib/pescarte_web/templates/landing_html/show.html.heex
@@ -118,16 +118,12 @@
         <div class="p-5">
           <a href="#">
             <.text size="h4" color="text-blue-100">
-              <%= PescarteWeb.LandingHTML.handle_notice_text_length(
-                "Doação do terreno em Cabo Frio.",
-                110
-              ) %>
+              <%= handle_notice_title_length("Doação do terreno em Cabo Frio.") %>
             </.text>
           </a>
           <.text size="sm" color="text-black-60">
-            <%= PescarteWeb.LandingHTML.handle_notice_text_length(
-              "e a mudança do marco regulatório do defeso do camarão na Laguna de Araruama..",
-              145
+            <%= handle_notice_desc_length(
+              "e a mudança do marco regulatório do defeso do camarão na Laguna de Araruama.."
             ) %>
           </.text>
           <DesignSystem.link href="/publicacoes" class="text-sm font-semibold">
@@ -144,16 +140,14 @@
         <div class="p-5">
           <a href="#">
             <.text size="h4" color="text-blue-100">
-              <%= PescarteWeb.LandingHTML.handle_notice_text_length(
-                " Diário de Bordo: falas de pessoas pescadoras que falam sobre a importância do PEA Pescarte",
-                110
+              <%= handle_notice_title_length(
+                " Diário de Bordo: falas de pessoas pescadoras que falam sobre a importância do PEA Pescarte"
               ) %>
             </.text>
           </a>
           <.text size="sm" color="text-black-60">
-            <%= PescarteWeb.LandingHTML.handle_notice_text_length(
-              "Proin nec ligula ultricies, finibus mi ac, pretium lectus. Nunc venenatis egestas finibus.",
-              145
+            <%= handle_notice_desc_length(
+              "Proin nec ligula ultricies, finibus mi ac, pretium lectus. Nunc venenatis egestas finibus."
             ) %>
           </.text>
           <DesignSystem.link href="/publicacoes" class="text-sm font-semibold">
@@ -170,16 +164,12 @@
         <div class="p-5">
           <a href="#">
             <.text size="h4" color="text-blue-100">
-              <%= PescarteWeb.LandingHTML.handle_notice_text_length(
-                "O Censo Pescarte continua nas ruas,",
-                110
-              ) %>
+              <%= handle_notice_title_length(" O Censo Pescarte continua nas ruas,") %>
             </.text>
           </a>
           <.text size="sm" color="text-black-60">
-            <%= PescarteWeb.LandingHTML.handle_notice_text_length(
-              "buscando encontrar e ouvir as pessoas pescadoras de nossa área de atuação.",
-              145
+            <%= handle_notice_desc_length(
+              "buscando encontrar e ouvir as pessoas pescadoras de nossa área de atuação."
             ) %>
           </.text>
           <DesignSystem.link href="/publicacoes" class="text-sm font-semibold">
@@ -196,14 +186,11 @@
         <div class="p-5">
           <a href="https://www.instagram.com/p/CzwyZf1Ccj2/?igsh=NTZiY2lleDRjbTlp">
             <.text size="h4" color="text-blue-100">
-              <%= PescarteWeb.LandingHTML.handle_notice_text_length("Seguro Defeso.", 110) %>
+              <%= handle_notice_title_length("Seguro Defeso.") %>
             </.text>
           </a>
           <.text size="sm" color="text-black-60">
-            <%= PescarteWeb.LandingHTML.handle_notice_text_length(
-              "Pescador, tire suas dúvidas aqui.",
-              145
-            ) %>
+            <%= handle_notice_desc_length("Pescador, tire suas dúvidas aqui.") %>
           </.text>
           <DesignSystem.link href="/publicacoes" class="text-sm font-semibold">
             <.button style="primary">

--- a/lib/pescarte_web/templates/landing_html/show.html.heex
+++ b/lib/pescarte_web/templates/landing_html/show.html.heex
@@ -118,16 +118,21 @@
         <div class="p-5">
           <a href="#">
             <.text size="h4" color="text-blue-100">
-              <%= PescarteWeb.LandingHTML.handle_notice_text_length("Doação do terreno em Cabo Frio.", 110) %>
+              <%= PescarteWeb.LandingHTML.handle_notice_text_length(
+                "Doação do terreno em Cabo Frio.",
+                110
+              ) %>
             </.text>
           </a>
           <.text size="sm" color="text-black-60">
-            <%= PescarteWeb.LandingHTML.handle_notice_text_length("e a mudança do marco regulatório do defeso do camarão na Laguna de Araruama..", 145) %>
-
+            <%= PescarteWeb.LandingHTML.handle_notice_text_length(
+              "e a mudança do marco regulatório do defeso do camarão na Laguna de Araruama..",
+              145
+            ) %>
           </.text>
           <DesignSystem.link href="/publicacoes" class="text-sm font-semibold">
             <.button style="primary">
-                <.text size="base" color="text-white-100">Ler mais</.text>
+              <.text size="base" color="text-white-100">Ler mais</.text>
             </.button>
           </DesignSystem.link>
         </div>
@@ -139,11 +144,17 @@
         <div class="p-5">
           <a href="#">
             <.text size="h4" color="text-blue-100">
-              <%= PescarteWeb.LandingHTML.handle_notice_text_length(" Diário de Bordo: falas de pessoas pescadoras que falam sobre a importância do PEA Pescarte", 110) %>
+              <%= PescarteWeb.LandingHTML.handle_notice_text_length(
+                " Diário de Bordo: falas de pessoas pescadoras que falam sobre a importância do PEA Pescarte",
+                110
+              ) %>
             </.text>
           </a>
           <.text size="sm" color="text-black-60">
-            <%= PescarteWeb.LandingHTML.handle_notice_text_length("Proin nec ligula ultricies, finibus mi ac, pretium lectus. Nunc venenatis egestas finibus.", 145) %>
+            <%= PescarteWeb.LandingHTML.handle_notice_text_length(
+              "Proin nec ligula ultricies, finibus mi ac, pretium lectus. Nunc venenatis egestas finibus.",
+              145
+            ) %>
           </.text>
           <DesignSystem.link href="/publicacoes" class="text-sm font-semibold">
             <.button style="primary">
@@ -159,11 +170,17 @@
         <div class="p-5">
           <a href="#">
             <.text size="h4" color="text-blue-100">
-              <%= PescarteWeb.LandingHTML.handle_notice_text_length("O Censo Pescarte continua nas ruas,", 110) %>
+              <%= PescarteWeb.LandingHTML.handle_notice_text_length(
+                "O Censo Pescarte continua nas ruas,",
+                110
+              ) %>
             </.text>
           </a>
           <.text size="sm" color="text-black-60">
-            <%= PescarteWeb.LandingHTML.handle_notice_text_length("buscando encontrar e ouvir as pessoas pescadoras de nossa área de atuação.", 145) %>
+            <%= PescarteWeb.LandingHTML.handle_notice_text_length(
+              "buscando encontrar e ouvir as pessoas pescadoras de nossa área de atuação.",
+              145
+            ) %>
           </.text>
           <DesignSystem.link href="/publicacoes" class="text-sm font-semibold">
             <.button style="primary">
@@ -183,7 +200,10 @@
             </.text>
           </a>
           <.text size="sm" color="text-black-60">
-            <%= PescarteWeb.LandingHTML.handle_notice_text_length("Pescador, tire suas dúvidas aqui.", 145) %>
+            <%= PescarteWeb.LandingHTML.handle_notice_text_length(
+              "Pescador, tire suas dúvidas aqui.",
+              145
+            ) %>
           </.text>
           <DesignSystem.link href="/publicacoes" class="text-sm font-semibold">
             <.button style="primary">

--- a/lib/pescarte_web/templates/landing_html/show.html.heex
+++ b/lib/pescarte_web/templates/landing_html/show.html.heex
@@ -118,17 +118,16 @@
         <div class="p-5">
           <a href="#">
             <.text size="h4" color="text-blue-100">
-              Doação do terreno em Cabo Frio.
+              <%= PescarteWeb.LandingHTML.handle_notice_text_length("Doação do terreno em Cabo Frio.", 110) %>
             </.text>
           </a>
           <.text size="sm" color="text-black-60">
-            e a mudança do marco regulatório do defeso do camarão na Laguna de Araruama..
+            <%= PescarteWeb.LandingHTML.handle_notice_text_length("e a mudança do marco regulatório do defeso do camarão na Laguna de Araruama..", 145) %>
+
           </.text>
-          <DesignSystem.link href="/not-found" class="text-sm font-semibold">
+          <DesignSystem.link href="/publicacoes" class="text-sm font-semibold">
             <.button style="primary">
-              <a href="https://drive.google.com/drive/u/1/folders/1w961gkYNiUKWUF2S8zkRBAI46iMkh9CR">
                 <.text size="base" color="text-white-100">Ler mais</.text>
-              </a>
             </.button>
           </DesignSystem.link>
         </div>
@@ -140,13 +139,13 @@
         <div class="p-5">
           <a href="#">
             <.text size="h4" color="text-blue-100">
-              Diário de Bordo: falas de pessoas pescadoras que falam sobre a importância do PEA Pescarte
+              <%= PescarteWeb.LandingHTML.handle_notice_text_length(" Diário de Bordo: falas de pessoas pescadoras que falam sobre a importância do PEA Pescarte", 110) %>
             </.text>
           </a>
           <.text size="sm" color="text-black-60">
-            Proin nec ligula ultricies, finibus mi ac, pretium lectus. Nunc venenatis egestas finibus.
+            <%= PescarteWeb.LandingHTML.handle_notice_text_length("Proin nec ligula ultricies, finibus mi ac, pretium lectus. Nunc venenatis egestas finibus.", 145) %>
           </.text>
-          <DesignSystem.link href="/not-found" class="text-sm font-semibold">
+          <DesignSystem.link href="/publicacoes" class="text-sm font-semibold">
             <.button style="primary">
               <.text size="base" color="text-white-100">Ler mais</.text>
             </.button>
@@ -160,13 +159,13 @@
         <div class="p-5">
           <a href="#">
             <.text size="h4" color="text-blue-100">
-              O Censo Pescarte continua nas ruas,
+              <%= PescarteWeb.LandingHTML.handle_notice_text_length("O Censo Pescarte continua nas ruas,", 110) %>
             </.text>
           </a>
           <.text size="sm" color="text-black-60">
-            buscando encontrar e ouvir as pessoas pescadoras de nossa área de atuação.
+            <%= PescarteWeb.LandingHTML.handle_notice_text_length("buscando encontrar e ouvir as pessoas pescadoras de nossa área de atuação.", 145) %>
           </.text>
-          <DesignSystem.link href="/not-found" class="text-sm font-semibold">
+          <DesignSystem.link href="/publicacoes" class="text-sm font-semibold">
             <.button style="primary">
               <.text size="base" color="text-white-100">Ler mais</.text>
             </.button>
@@ -180,13 +179,13 @@
         <div class="p-5">
           <a href="https://www.instagram.com/p/CzwyZf1Ccj2/?igsh=NTZiY2lleDRjbTlp">
             <.text size="h4" color="text-blue-100">
-              Seguro Defeso.
+              <%= PescarteWeb.LandingHTML.handle_notice_text_length("Seguro Defeso.", 110) %>
             </.text>
           </a>
           <.text size="sm" color="text-black-60">
-            Pescador, tire suas dúvidas aqui.
+            <%= PescarteWeb.LandingHTML.handle_notice_text_length("Pescador, tire suas dúvidas aqui.", 145) %>
           </.text>
-          <DesignSystem.link href="/not-found" class="text-sm font-semibold">
+          <DesignSystem.link href="/publicacoes" class="text-sm font-semibold">
             <.button style="primary">
               <.text size="base" color="text-white-100">Ler mais</.text>
             </.button>


### PR DESCRIPTION
# Descrição
PR feito para redirecionar os links dos botões de "Saiba Mais" nas notícias da Landing e também para formatar os textos presentes nos cards de notícias, caso o texto ultrapasse a quantidade de caracteres permitidos, são removidos os três últimos caracteres e exibidas reticências, indicando que o texto ainda não foi concluído. 


## Stories relacionadas (Shortcut)
- [sc-xxxx]


## Pontos para atenção
- Função `handle_notice_text_length/2` criada no módulo PescarteWEB.LandingHTML, feita para formatar os textos caso necessário.
### Texto formatado quando o limite de caracteres é ultrapassado: 

![image](https://github.com/user-attachments/assets/8ee63455-af9b-400e-a812-a8314b3f6270)



## Possui novas configurações?
- Precisei fazer um `npm install esbuild-sass`, notei que alterou a versão que até então era utilizada no projeto. 


## Possui migrations?
- Não


